### PR TITLE
Fix/copy guard migration

### DIFF
--- a/Classes/Controller/ImportController.php
+++ b/Classes/Controller/ImportController.php
@@ -65,7 +65,7 @@ class ImportController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     /**
      * @param \RKW\RkwResourcespace\Domain\Repository\BackendUserRepository $backendUserRepository
      */
-    public function injectMBackendUserRepository(BackendUserRepository $backendUserRepository)
+    public function injectBackendUserRepository(BackendUserRepository $backendUserRepository)
     {
         $this->backendUserRepository = $backendUserRepository;
     }

--- a/Classes/Domain/Model/FileMetadata.php
+++ b/Classes/Domain/Model/FileMetadata.php
@@ -14,6 +14,8 @@ namespace RKW\RkwResourcespace\Domain\Model;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Madj2k\CopyrightGuardian\Domain\Model\MediaSource;
+
 /**
  * Class FileMetadata
  *
@@ -24,6 +26,60 @@ namespace RKW\RkwResourcespace\Domain\Model;
  */
 class FileMetadata extends \Madj2k\CoreExtended\Domain\Model\FileMetadata
 {
+    /**
+     * @var string
+     */
+    protected string $txCopyrightguardianCreator = '';
 
+
+    /**
+     * @var \Madj2k\CopyrightGuardian\Domain\Model\MediaSource|null
+     */
+    protected ?MediaSource $txCopyrightguardianSource = null;
+
+    /**
+     * Returns the txCopyrightguardianCreator
+     *
+     * @return string
+     */
+    public function getTxCopyrightguardianCreator(): string
+    {
+        return $this->txCopyrightguardianCreator;
+    }
+
+
+    /**
+     * Sets the txCopyrightguardianCreator
+     *
+     * @param string $txCopyrightguardianCreator
+     * @return void
+     */
+    public function setTxCopyrightguardianCreator(string $txCopyrightguardianCreator)
+    {
+        $this->txCopyrightguardianCreator = $txCopyrightguardianCreator;
+    }
+
+
+    /**
+     * Returns the txCopyrightguardianSource
+     *
+     * @return \Madj2k\CopyrightGuardian\Domain\Model\MediaSource|null
+     */
+    public function getTxCopyrightguardianSource(): ?MediaSource
+    {
+        return $this->txCopyrightguardianSource;
+    }
+
+
+    /**
+     * Sets the txCopyrightguardianSource
+     *
+     * @param \Madj2k\CopyrightGuardian\Domain\Model\MediaSource $txCopyrightguardianSource
+     * @return void
+     */
+    public function setTxCopyrightguardianSource(MediaSource $txCopyrightguardianSource)
+    {
+        $this->txCopyrightguardianSource = $txCopyrightguardianSource;
+    }
 
 }

--- a/Classes/Domain/Model/MediaSource.php
+++ b/Classes/Domain/Model/MediaSource.php
@@ -16,14 +16,14 @@ namespace RKW\RkwResourcespace\Domain\Model;
  */
 
 /**
- * Class MediaSources
+ * Class MediaSource
  *
  * @author Maximilian Fäßler <maximilian@faesslerweb.de>
  * @copyright RKW Kompetenzzentrum
  * @package RKW_Resourcespace
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
-class MediaSources extends \Madj2k\CoreExtended\Domain\Model\MediaSources
+class MediaSource extends \Madj2k\CopyrightGuardian\Domain\Model\MediaSource
 {
 
 }

--- a/Classes/Domain/Repository/MediaSourceRepository.php
+++ b/Classes/Domain/Repository/MediaSourceRepository.php
@@ -14,25 +14,25 @@ namespace RKW\RkwResourcespace\Domain\Repository;
  * The TYPO3 project - inspiring people to share!
  */
 
-use RKW\RkwResourcespace\Domain\Model\MediaSources;
+use RKW\RkwResourcespace\Domain\Model\MediaSource;
 
 /**
- * Class MediaSourcesRepository
+ * Class MediaSourceRepository
  *
  * @author Maximilian Fäßler <maximilian@faesslerweb.de>
  * @copyright RKW Kompetenzzentrum
  * @package RKW_Resourcespace
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
-class MediaSourcesRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
+class MediaSourceRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
     /**
      * Find one by partial string
      *
      * @param string $search
-     * @return object|\RKW\RkwResourcespace\Domain\Model\MediaSources
+     * @return object|\RKW\RkwResourcespace\Domain\Model\MediaSource
      */
-    public function findOneByNameLike(string $search):? MediaSources
+    public function findOneByNameLike(string $search):? MediaSource
     {
         $query = $this->createQuery();
 
@@ -46,7 +46,7 @@ class MediaSourcesRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
         $query->statement('
 			SELECT *
 			FROM
-				tx_coreextended_domain_model_mediasources
+				tx_copyrightguardian_domain_model_mediasource
 			WHERE
 				name LIKE "%' . $search . '%"
 		');

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -18,10 +18,10 @@ use Madj2k\CoreExtended\Utility\GeneralUtility;
 use RKW\RkwResourcespace\Domain\Model\FileMetadata;
 use RKW\RkwResourcespace\Domain\Model\FileReference;
 use RKW\RkwResourcespace\Domain\Model\Import;
-use RKW\RkwResourcespace\Domain\Model\MediaSources;
+use RKW\RkwResourcespace\Domain\Model\MediaSource;
 use RKW\RkwResourcespace\Domain\Repository\FileRepository;
 use RKW\RkwResourcespace\Domain\Repository\FileMetadataRepository;
-use RKW\RkwResourcespace\Domain\Repository\MediaSourcesRepository;
+use RKW\RkwResourcespace\Domain\Repository\MediaSourceRepository;
 use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
@@ -277,7 +277,6 @@ class FileUtility implements \TYPO3\CMS\Core\SingletonInterface
                 }
             }
 
-            try {
                 /** @var \TYPO3\CMS\Core\Resource\File $newFileObject */
                 $newFileObject = $storage->addFile(
                     $this->tempName,
@@ -318,18 +317,7 @@ class FileUtility implements \TYPO3\CMS\Core\SingletonInterface
                     'rkw_resourcespace'
                 );
 
-            } catch (\Exception $e) {
-                $this->getLogger()->log(
-                    \TYPO3\CMS\Core\Log\LogLevel::ERROR,
-                    sprintf('Error while trying to create image in TYPO3: %s', $e->getMessage())
-                );
 
-                // return message
-                return LocalizationUtility::translate(
-                    'tx_rkwresourcespace_helper_file.errorMisconfiguration',
-                    'rkw_resourcespace'
-                );
-            }
 
         } else {
             $this->getLogger()->log(
@@ -392,25 +380,25 @@ class FileUtility implements \TYPO3\CMS\Core\SingletonInterface
             switch ($metaDataEntry->resource_type_field) {
                 // 'source'
                 case 76:
-                    /** @var \RKW\RkwResourcespace\Domain\Repository\MediaSourcesRepository $mediaSourcesRepository */
-                    $mediaSourcesRepository = $this->objectManager->get(MediaSourcesRepository::class);
-                    $mediaSource = $mediaSourcesRepository->findOneByNameLike($metaDataEntry->value);
+                    /** @var \RKW\RkwResourcespace\Domain\Repository\MediaSourceRepository $mediaSourceRepository */
+                    $mediaSourceRepository = $this->objectManager->get(MediaSourceRepository::class);
+                    $mediaSource = $mediaSourceRepository->findOneByNameLike($metaDataEntry->value);
                     if ($mediaSource) {
                         // use existing
-                        $newFileMetadata->setTxCoreextendedSource($mediaSource);
+                        $newFileMetadata->setTxCopyrightguardianSource($mediaSource);
                     } else {
                         // create & add new
-                        /** @var \RKW\RkwResourcespace\Domain\Model\MediaSources $newMediaSource */
-                        $newMediaSource = $this->objectManager->get(MediaSources::class);
+                        /** @var \RKW\RkwResourcespace\Domain\Model\MediaSource $newMediaSource */
+                        $newMediaSource = $this->objectManager->get(MediaSource::class);
                         $newMediaSource->setName($metaDataEntry->value);
-                        $mediaSourcesRepository->add($newMediaSource);
+                        $mediaSourceRepository->add($newMediaSource);
                         // set new
-                        $newFileMetadata->setTxCoreextendedSource($newMediaSource);
+                        $newFileMetadata->setTxCopyrightguardianSource($newMediaSource);
                     }
                     break;
                 // 'credit'
                 case 10:
-                    $newFileMetadata->setTxCoreextendedPublisher(filter_var($metaDataEntry->value, FILTER_SANITIZE_STRING));
+                    $newFileMetadata->setTxCopyrightguardianCreator(filter_var($metaDataEntry->value, FILTER_SANITIZE_STRING));
                     break;
                 // 'title'
                 case 8:

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -277,6 +277,7 @@ class FileUtility implements \TYPO3\CMS\Core\SingletonInterface
                 }
             }
 
+            try {
                 /** @var \TYPO3\CMS\Core\Resource\File $newFileObject */
                 $newFileObject = $storage->addFile(
                     $this->tempName,
@@ -317,7 +318,18 @@ class FileUtility implements \TYPO3\CMS\Core\SingletonInterface
                     'rkw_resourcespace'
                 );
 
+            } catch (\Exception $e) {
+                $this->getLogger()->log(
+                    \TYPO3\CMS\Core\Log\LogLevel::ERROR,
+                    sprintf('Error while trying to create image in TYPO3: %s', $e->getMessage())
+                );
 
+                // return message
+                return LocalizationUtility::translate(
+                    'tx_rkwresourcespace_helper_file.errorMisconfiguration',
+                    'rkw_resourcespace'
+                );
+            }
 
         } else {
             $this->getLogger()->log(

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -26,8 +26,8 @@ return [
             ],
         ],
     ],
-    \RKW\RkwResourcespace\Domain\Model\MediaSources::class => [
-        'tableName' => 'tx_coreextended_domain_model_mediasources',
+    \RKW\RkwResourcespace\Domain\Model\MediaSource::class => [
+        'tableName' => 'tx_copyrightguardian_domain_model_mediasource',
     ],
     \RKW\RkwResourcespace\Domain\Model\BackendUser::class => [
         'tableName' => 'be_users',

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -56,15 +56,15 @@ config.tx_extbase.persistence {
 		}
 
 		// ==================================================================
-        Madj2k\CoreExtended\Domain\Model\MediaSources {
+        Madj2k\CopyrightGuardian\Domain\Model\MediaSource {
             subclasses {
-                Tx_Ressourcespace_MediaSources = RKW\RkwResourcespace\Domain\Model\MediaSources
+                Tx_Ressourcespace_MediaSource = RKW\RkwResourcespace\Domain\Model\MediaSource
             }
         }
 
-		RKW\RkwResourcespace\Domain\Model\MediaSources {
+		RKW\RkwResourcespace\Domain\Model\MediaSource {
 			mapping {
-				tableName = tx_coreextended_domain_model_mediasources
+				tableName = tx_copyrightguardian_domain_model_mediasource
 			}
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": ">=7.4",
 		"ext-json" : "*",
 		"typo3/cms-core": "~10.4.0",
-		"madj2k/t3-core-extended": "~10.4.0 || ~11.5.0 || ~12.4.0"
+		"madj2k/t3-core-extended": "~10.4.0 || ~11.5.0 || ~12.4.0",
+		"madj2k/t3-copyright-guardian": "~12.4.0"
 	},
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -25,6 +25,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '10.4.0-10.4.99',
             'core_extended' => '10.4.0-12.4.99',
+            'copyright_guardian' => '12.4.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -64,14 +64,14 @@ call_user_func(
 
         // for TYPO3 12+
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\Madj2k\CoreExtended\Domain\Model\MediaSources::class] = [
-            'className' => \RKW\RkwResourcespace\Domain\Model\MediaSources::class
+            'className' => \RKW\RkwResourcespace\Domain\Model\MediaSource::class
         ];
 
         // for TYPO3 9.5 - 11.5 only, not required for TYPO3 12
         \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\Container\Container::class)
             ->registerImplementation(
                 \Madj2k\CoreExtended\Domain\Model\MediaSources::class,
-                \RKW\RkwResourcespace\Domain\Model\MediaSources::class
+                \RKW\RkwResourcespace\Domain\Model\MediaSource::class
             );
 
         // for TYPO3 12+


### PR DESCRIPTION
- migration from coreExtended->MediaSources to copyrightGuardian->MediaSource
- change plural of old property to new singular

-> Check for additional MySQL-Query on merge this branch (see: readMe of EXT:copyright_guardian)